### PR TITLE
fix: reset modal state on close

### DIFF
--- a/src/core/Modal.tsx
+++ b/src/core/Modal.tsx
@@ -58,6 +58,11 @@ const DeLabModal: React.FC<DeLabModalConfig> = (props: DeLabModalConfig) => {
 
             setActiveModal(data.data ? 'connect' : null)
             // console.log('modal', data.data)
+
+            if (!data.data) {
+                setType(0)
+                setLink('')
+            }
         })
 
         props.DeLabConnectObject.on('link', (data: DeLabEvent) => {


### PR DESCRIPTION
This PR forces modal component to reset state on close event. Currently outside clicks persist modal type and link while this IMO is a bad UX. For example, pancakeswap or uniswap reset their modal state on outside clicks.

https://user-images.githubusercontent.com/31648261/199529078-daaadd03-ba66-4004-bace-bffd4b570303.mov

