### PR TITLE
fix: add main components DeLabConnectObject type

### DIFF
--- a/src/core/types/index.tsx
+++ b/src/core/types/index.tsx
@@ -1,3 +1,5 @@
+import { DeLabConnect } from "index";
+
 type DeLabEvent = {
     data?: any;
 } & Event
@@ -27,12 +29,12 @@ interface DeLabTransaction {
     payload?: string // Optional serialized to base64 string payload cell
 }
 interface DeLabModalConfig {
-    DeLabConnectObject: any,
+    DeLabConnectObject: DeLabConnect,
     scheme: DeLabScheme
 }
 
 interface DeLabButtonConfig {
-    DeLabConnectObject: any,
+    DeLabConnectObject: DeLabConnect,
     scheme: DeLabScheme
 }
 


### PR DESCRIPTION
This RP fixes missing DeLabConnectObject type annotation for more explicit typescript usage 